### PR TITLE
Sync product GTIN when available

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -735,6 +735,11 @@ class WC_Facebook_Product {
 			}
 		}
 
+		// Add GTIN (Global Trade Item Number)
+		if ( $gtin = $this->woo_product->get_global_unique_id() ) {
+			$product_data['gtin'] = $gtin;
+		}
+
 		// Only use checkout URLs if they exist.
 		$checkout_url = $this->build_checkout_url( $product_url );
 		if ( $checkout_url ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -11,6 +11,7 @@
 
 require_once __DIR__ . '/fbutils.php';
 
+use WooCommerce\Facebook\Framework\Plugin\Compatibility;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Products;
 
@@ -736,7 +737,7 @@ class WC_Facebook_Product {
 		}
 
 		// Add GTIN (Global Trade Item Number)
-		if ( $gtin = $this->woo_product->get_global_unique_id() ) {
+		if ( Compatibility::is_wc_version_gte( '9.1.0' ) && $gtin = $this->woo_product->get_global_unique_id() ) {
 			$product_data['gtin'] = $gtin;
 		}
 

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -304,4 +304,60 @@ class fbproductTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $data['quantity_to_sell_on_facebook'], 128 );
 	}
+
+	/**
+	 * Test GTIN is added for simple product 
+	 * @return void
+	 */
+	public function test_gtin_for_simple_product_set() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		$woo_product->set_global_unique_id(9504000059446);
+		
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['gtin'], 9504000059446 );
+	}
+
+	/**
+	 * Test GTIN is not added for simple product
+	 * @return void
+	 */
+	public function test_gtin_for_simple_product_unset() {
+		$woo_product = WC_Helper_Product::create_simple_product();
+		$fb_product = new \WC_Facebook_Product( $woo_product );
+		$data = $fb_product->prepare_product();
+		$this->assertEquals(isset($data['gtin']), false);
+	}
+
+	/**
+	 * Test GTIN is added for variable product
+	 * @return void
+	 */
+	public function test_gtin_for_variable_product_set() {
+		$woo_product = WC_Helper_Product::create_variation_product();
+		$woo_variation = wc_get_product($woo_product->get_children()[0]);
+		$woo_variation->set_global_unique_id(9504000059446);
+
+		$fb_parent_product = new \WC_Facebook_Product($woo_product);
+		$fb_product = new \WC_Facebook_Product( $woo_variation, $fb_parent_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals( $data['gtin'], 9504000059446 );
+	}
+
+	/**
+	 * Test GTIN is not added for variable product
+	 * @return void
+	 */
+	public function test_gtin_for_variable_product_unset() {
+		$woo_product = WC_Helper_Product::create_variation_product();
+		$woo_variation = wc_get_product($woo_product->get_children()[0]);
+
+		$fb_parent_product = new \WC_Facebook_Product($woo_product);
+		$fb_product = new \WC_Facebook_Product( $woo_variation, $fb_parent_product );
+		$data = $fb_product->prepare_product();
+
+		$this->assertEquals(isset($data['gtin']), false);
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This change suggests to sync to Facebook a product GTIN if is it available.

### Screenshots:
N/A (no changes to UI/UX)

### Detailed test instructions:
1. Run new tests
./vendor/bin/phpunit --filter test_gtin_for_simple_product_set
./vendor/bin/phpunit --filter test_gtin_for_simple_product_unset
./vendor/bin/phpunit --filter test_gtin_for_variable_product_set
./vendor/bin/phpunit --filter test_gtin_for_variable_product_unset

2. Run all tests
npm run test:php

3. Lint
./vendor/bin/phpcs

4. Manual testing. I tested this in the locally hosted WP WooCommerce website and checked logs on Meta side to verify the request is being sent with the "gtin" populated correctly. Tested on both simple and variable product. 

### Changelog entry
Fix - Sync product GTIN when available.
